### PR TITLE
Round trip publish and replicate 

### DIFF
--- a/legacy-msg-data/src/json/mod.rs
+++ b/legacy-msg-data/src/json/mod.rs
@@ -8,5 +8,7 @@
 mod de;
 mod ser;
 
-pub use self::de::{JsonDeserializer, DecodeJsonError, ErrorCode, from_slice, from_slice_partial};
-pub use self::ser::{JsonSerializer, EncodeJsonError, to_writer, to_vec, to_string, to_writer_indent};
+pub use self::de::{from_slice, from_slice_partial, DecodeJsonError, ErrorCode, JsonDeserializer};
+pub use self::ser::{
+    to_string, to_vec, to_writer, to_writer_indent, EncodeJsonError, JsonSerializer,
+};

--- a/legacy-msg-data/src/lib.rs
+++ b/legacy-msg-data/src/lib.rs
@@ -7,17 +7,17 @@
 //! [json transport encoding](https://spec.scuttlebutt.nz/datamodel.html#json-transport-encoding).
 #![warn(missing_docs)]
 
+extern crate encode_unicode;
 extern crate indexmap;
 extern crate ryu_ecmascript;
-extern crate strtod;
-extern crate encode_unicode;
 extern crate serde;
+extern crate strtod;
 #[macro_use]
 extern crate serde_derive;
 extern crate base64;
 
-pub mod value;
 pub mod json;
+pub mod value;
 
 use std::cmp::Ordering;
 use std::fmt;

--- a/rustle/Cargo.toml
+++ b/rustle/Cargo.toml
@@ -20,6 +20,7 @@ ssb-db = {path= "../../ssb-db"}
 ssb-handshake = "0.5.0"
 ssb-multiformats = { git = "https://github.com/sunrise-choir/ssb-multiformats"}
 ssb-packetstream = { version = "0.1.0", path = "../ssb-packetstream" }
+ssb-publish = { git = "https://github.com/sunrise-choir/ssb-publish", version = "0.3.0"}
 ssb-verify-signatures = {path= "../../ssb-verify-signatures"}
 ssb-validate = {path= "../../ssb-validate"}
 uuid = { version = "0.7", features = ["v4"] }

--- a/rustle/Cargo.toml
+++ b/rustle/Cargo.toml
@@ -14,9 +14,13 @@ serde = "~1.0.90"
 serde_derive = "~1.0.90"
 serde_json = "~1.0.39"
 snafu = { version = "0.6.0", features = ["futures"] }
-ssb-crypto = "~0.1.3"
-ssb-handshake = "0.5.0"
 ssb-boxstream = "0.2.0"
+ssb-crypto = "~0.1.3"
+ssb-db = {path= "../../ssb-db"}
+ssb-handshake = "0.5.0"
+ssb-multiformats = { git = "https://github.com/sunrise-choir/ssb-multiformats"}
 ssb-packetstream = { version = "0.1.0", path = "../ssb-packetstream" }
+ssb-verify-signatures = {path= "../../ssb-verify-signatures"}
+ssb-validate = {path= "../../ssb-validate"}
 uuid = { version = "0.7", features = ["v4"] }
 async-std = "1.1.0"

--- a/rustle/Cargo.toml
+++ b/rustle/Cargo.toml
@@ -16,12 +16,12 @@ serde_json = "~1.0.39"
 snafu = { version = "0.6.0", features = ["futures"] }
 ssb-boxstream = {path = "../../ssb-boxstream"}
 ssb-crypto = "~0.1.3"
-ssb-db = {path= "../../ssb-db"}
+ssb-db = {git = "https://github.com/sunrise-choir/ssb_db"}
 ssb-handshake = "0.5.0"
 ssb-multiformats = { git = "https://github.com/sunrise-choir/ssb-multiformats"}
 ssb-packetstream = { version = "0.1.0", path = "../ssb-packetstream" }
 ssb-publish = { git = "https://github.com/sunrise-choir/ssb-publish", version = "0.3.0"}
-ssb-verify-signatures = {path= "../../ssb-verify-signatures"}
-ssb-validate = {path= "../../ssb-validate"}
+ssb-verify-signatures = {git= "https://github.com/sunrise-choir/ssb-verify-signatures"}
+ssb-validate = {git= "https://github.com/sunrise-choir/ssb-validate"}
 uuid = { version = "0.7", features = ["v4"] }
 async-std = "1.1.0"

--- a/rustle/Cargo.toml
+++ b/rustle/Cargo.toml
@@ -14,7 +14,7 @@ serde = "~1.0.90"
 serde_derive = "~1.0.90"
 serde_json = "~1.0.39"
 snafu = { version = "0.6.0", features = ["futures"] }
-ssb-boxstream = "0.2.0"
+ssb-boxstream = {path = "../../ssb-boxstream"}
 ssb-crypto = "~0.1.3"
 ssb-db = {path= "../../ssb-db"}
 ssb-handshake = "0.5.0"

--- a/rustle/Cargo.toml
+++ b/rustle/Cargo.toml
@@ -14,7 +14,7 @@ serde = "~1.0.90"
 serde_derive = "~1.0.90"
 serde_json = "~1.0.39"
 snafu = { version = "0.6.0", features = ["futures"] }
-ssb-boxstream = {path = "../../ssb-boxstream"}
+ssb-boxstream = {git = "https://github.com/sunrise-choir/ssb-boxstream"}
 ssb-crypto = "~0.1.3"
 ssb-db = {git = "https://github.com/sunrise-choir/ssb_db"}
 ssb-handshake = "0.5.0"

--- a/rustle/src/main.rs
+++ b/rustle/src/main.rs
@@ -1,39 +1,45 @@
 #![allow(unused_imports)]
 
-use std::io::{self, BufRead, BufReader, Read};
 use std::fs::{File, OpenOptions};
+use std::io::{self, BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::str;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use base64::{decode_config_slice, STANDARD};
-use clap::{Arg, App, SubCommand};
+use clap::{App, Arg, SubCommand};
 
 use flumedb::flume_log::{self, FlumeLog};
-use flumedb::offset_log::{BidirIterator, OffsetLog, LogEntry};
+use flumedb::offset_log::{BidirIterator, LogEntry, OffsetLog};
 
-use futures::StreamExt;
 use futures::channel::mpsc::Receiver;
 use futures::executor::{self, block_on, LocalPool, ThreadPool};
 use futures::future::join;
-use futures::task::LocalSpawnExt;
 use futures::io::{AsyncReadExt, AsyncWriteExt};
 use futures::prelude::*;
 use futures::sink::SinkExt;
+use futures::task::LocalSpawnExt;
+use futures::StreamExt;
 
-use futures::task::{SpawnExt};
 use async_std::net::{TcpListener, TcpStream};
+use futures::task::SpawnExt;
 
-#[macro_use] extern crate serde_json;
-#[macro_use] extern crate serde_derive;
+#[macro_use]
+extern crate serde_json;
+#[macro_use]
+extern crate serde_derive;
 
 use serde_json::json;
 
-use ssb_crypto::{NetworkKey, PublicKey, SecretKey};
-use ssb_handshake::client;
-use ssb_boxstream::BoxStream;
-use ssb_packetstream::{mux, ChildError, MuxChildSender, Packet, BodyType};
 use snafu::{ResultExt, Snafu};
+use ssb_boxstream::BoxStream;
+use ssb_crypto::{NetworkKey, PublicKey, SecretKey};
+use ssb_db::{SqliteSsbDb, SsbDb};
+use ssb_handshake::client;
+use ssb_multiformats::multikey::Multikey;
+use ssb_packetstream::{mux, BodyType, ChildError, MuxChildSender, Packet};
+use ssb_validate::par_validate_message_hash_chain_of_feed;
+use ssb_verify_signatures::par_verify_messages;
 use uuid::Uuid;
 
 #[derive(Debug, Snafu)]
@@ -50,7 +56,6 @@ pub enum Error {
 
     #[snafu(display("Flume error: {}", source))]
     FlumeIo { source: std::io::Error },
-
 }
 
 #[derive(Debug, Deserialize)]
@@ -67,8 +72,14 @@ fn ms_since_1970() -> u128 {
 
 fn log_packet(p: &Packet) {
     let s = str::from_utf8(&p.body).unwrap();
-    eprintln!("In: {} strm:{:?} end:{:?} {:?} {}",
-              p.id, p.is_stream(), p.is_end(), p.body_type, s);
+    eprintln!(
+        "In: {} strm:{:?} end:{:?} {:?} {}",
+        p.id,
+        p.is_stream(),
+        p.is_end(),
+        p.body_type,
+        s
+    );
 }
 
 fn decode_b64_key(s: &str) -> Vec<u8> {
@@ -78,10 +89,12 @@ fn decode_b64_key(s: &str) -> Vec<u8> {
 fn load_keys_from_path(path: &str) -> io::Result<(PublicKey, SecretKey)> {
     let f = BufReader::new(File::open(path)?);
 
-    let sec_str = f.lines()
+    let sec_str = f
+        .lines()
         .filter_map(|s| s.ok())
         .filter(|s| !s.starts_with('#'))
-        .collect::<Vec<String>>().concat();
+        .collect::<Vec<String>>()
+        .concat();
 
     // let v = serde_json::from_str::<serde_json::Value>(&sec_str)?;
     let sec = serde_json::from_str::<SecretFile>(&sec_str)?;
@@ -92,13 +105,16 @@ fn load_keys_from_path(path: &str) -> io::Result<(PublicKey, SecretKey)> {
     Ok((p, s))
 }
 
-async fn bumrpc(p: Packet, _out: MuxChildSender, _inn: Option<Receiver<Packet>>)
-                -> Result<(), Error> {
+async fn bumrpc(
+    p: Packet,
+    _out: MuxChildSender,
+    _inn: Option<Receiver<Packet>>,
+) -> Result<(), Error> {
     log_packet(&p);
     Ok(())
 }
 
-fn create_hist_stream_msg(feed_id: &str, start: u32, limit: u32) -> Vec<u8> {
+fn create_hist_stream_msg(feed_id: &str, start: u32, limit: Option<u32>) -> Vec<u8> {
     serde_json::to_vec(&json!({
         "name": ["createHistoryStream"],
         "args": [{
@@ -107,7 +123,8 @@ fn create_hist_stream_msg(feed_id: &str, start: u32, limit: u32) -> Vec<u8> {
             "limit": limit,
             "live": false,
         }],
-        "type":"source"})).unwrap()
+        "type":"source"}))
+    .unwrap()
 }
 
 fn temp_path() -> String {
@@ -116,64 +133,207 @@ fn temp_path() -> String {
 }
 
 fn main() -> Result<(), Error> {
-
     let default_out_path = temp_path();
 
     let app_m = App::new("rustle")
         .version("0.1")
         .author("Sunrise Choir (sunrisechoir.com)")
         .about("")
-        .arg(Arg::with_name("secret")
-             .long("secret-file")
-             .short("s")
-             .required(true)
-             .takes_value(true)
-             .help("ssb secret (key) file"))
-        .subcommand(SubCommand::with_name("getfeed")
-                    .about("Send createHistoryStream request")
-                    .arg(Arg::with_name("addr")
-                         .long("addr")
-                         .short("a")
-                         .takes_value(true)
-                         .default_value("127.0.0.1:8008")
-                         .help("ip:port of peer"))
-                    .arg(Arg::with_name("key")
-                         .long("key")
-                         .short("k")
-                         .required(true)
-                         .takes_value(true)
-                         .help("base64-encoded public key of peer"))
-                    .arg(Arg::with_name("feed")
-                         .long("feed")
-                         .short("f")
-                         .required(true)
-                         .takes_value(true)
-                         .help("feed (user) id (eg. \"@N/vWpVVdD...\""))
-                    .arg(Arg::with_name("seq")
-                         .long("seq")
-                         .short("q")
-                         .takes_value(true)
-                         .default_value("0")
-                         .help(""))
-                    .arg(Arg::with_name("limit")
-                         .long("limit")
-                         .short("n")
-                         .takes_value(true)
-                         .default_value("10")
-                         .help(""))
-                    .arg(Arg::with_name("out")
-                         .long("out")
-                         .short("o")
-                         .takes_value(true)
-                         .default_value(&default_out_path)
-                         .help(""))
-                    .arg(Arg::with_name("overwrite")
-                         .long("overwrite")
-                         .help("Overwrite output file, if it exists."))
+        .arg(
+            Arg::with_name("secret")
+                .long("secret-file")
+                .short("s")
+                .required(true)
+                .takes_value(true)
+                .help("ssb secret (key) file"),
+        )
+        .subcommand(
+            SubCommand::with_name("replicatefeed")
+                .about("Replicate a feed into a ssb_db")
+                .arg(
+                    Arg::with_name("addr")
+                        .long("addr")
+                        .short("a")
+                        .takes_value(true)
+                        .default_value("127.0.0.1:8008")
+                        .help("ip:port of peer"),
+                )
+                .arg(
+                    Arg::with_name("key")
+                        .long("key")
+                        .short("k")
+                        .required(true)
+                        .takes_value(true)
+                        .help("base64-encoded public key of peer"),
+                )
+                .arg(
+                    Arg::with_name("feed")
+                        .long("feed")
+                        .short("f")
+                        .required(true)
+                        .takes_value(true)
+                        .help("feed (user) id (eg. \"@N/vWpVVdD...\""),
+                )
+                .arg(
+                    Arg::with_name("offsetpath")
+                        .long("offsetpath")
+                        .short("o")
+                        .required(true)
+                        .takes_value(true)
+                        .help("path to ssb_db offset file"),
+                )
+                .arg(
+                    Arg::with_name("dbpath")
+                        .long("dbpath")
+                        .short("db")
+                        .required(true)
+                        .takes_value(true)
+                        .help("path to ssb_db sqlite file"),
+                ),
+        )
+        .subcommand(
+            SubCommand::with_name("getfeed")
+                .about("Send createHistoryStream request")
+                .arg(
+                    Arg::with_name("addr")
+                        .long("addr")
+                        .short("a")
+                        .takes_value(true)
+                        .default_value("127.0.0.1:8008")
+                        .help("ip:port of peer"),
+                )
+                .arg(
+                    Arg::with_name("key")
+                        .long("key")
+                        .short("k")
+                        .required(true)
+                        .takes_value(true)
+                        .help("base64-encoded public key of peer"),
+                )
+                .arg(
+                    Arg::with_name("feed")
+                        .long("feed")
+                        .short("f")
+                        .required(true)
+                        .takes_value(true)
+                        .help("feed (user) id (eg. \"@N/vWpVVdD...\""),
+                )
+                .arg(
+                    Arg::with_name("seq")
+                        .long("seq")
+                        .short("q")
+                        .takes_value(true)
+                        .default_value("0")
+                        .help(""),
+                )
+                .arg(
+                    Arg::with_name("limit")
+                        .long("limit")
+                        .short("n")
+                        .takes_value(true)
+                        .default_value("10")
+                        .help(""),
+                )
+                .arg(
+                    Arg::with_name("out")
+                        .long("out")
+                        .short("o")
+                        .takes_value(true)
+                        .default_value(&default_out_path)
+                        .help(""),
+                )
+                .arg(
+                    Arg::with_name("overwrite")
+                        .long("overwrite")
+                        .help("Overwrite output file, if it exists."),
+                ),
         )
         .get_matches();
 
     match app_m.subcommand() {
+        ("replicatefeed", Some(sub_m)) => {
+            let secret_path = app_m.value_of("secret").unwrap();
+            let feed_id = sub_m.value_of("feed").unwrap();
+
+            let peer_key = sub_m.value_of("key").unwrap();
+            let peer_addr = sub_m.value_of("addr").unwrap();
+            let offset_log_path = sub_m.value_of("offsetpath").unwrap();
+            let db_path = sub_m.value_of("dbpath").unwrap();
+
+            let db = SqliteSsbDb::new(db_path, offset_log_path);
+
+            let author = Multikey::from_legacy(&feed_id.as_bytes()).unwrap().0;
+            let latest_seq = db.get_feed_latest_sequence(&author).unwrap().unwrap_or(0);
+
+            eprintln!("Latest sequence for feed is {}", latest_seq);
+
+            let (pk, sk) = load_keys_from_path(&secret_path).context(ReadSecretFile)?;
+
+            let net_id = NetworkKey::SSB_MAIN_NET;
+
+            // ./rustle --secret-file ~/.testnet/secret getfeed --feed "@U5GvOKP/YUza9k53DSXxT0mk3PIrnyAmessvNfZl5E0=.ed25519" --addr "134.209.164.64:8008" --key "/1OZ3fUmzKcaKyuyw5ffFHcpStayDTco9zMN7R1ZE84="
+
+            // let key = "U5GvOKP/YUza9k53DSXxT0mk3PIrnyAmessvNfZl5E0=";
+            // let addr = "127.0.0.1:8008";
+
+            let server_pk = PublicKey::from_slice(&base64::decode(peer_key).unwrap()).unwrap();
+            let (box_r, box_w) = block_on(async {
+                let mut tcp = TcpStream::connect(&peer_addr)
+                    .await
+                    .context(TcpConnection)?;
+                let o = client(&mut tcp, net_id, pk, sk, server_pk).await.unwrap();
+
+                let (tcp_r, tcp_w) = tcp.split();
+                Ok(BoxStream::client_side(tcp_r, tcp_w, o).split())
+            })?;
+            eprintln!("client connected");
+
+            let mut pool = LocalPool::new();
+            let spawner = pool.spawner();
+
+            let (mut out, done) = mux(box_r, box_w, bumrpc);
+            let done = spawner.spawn_local_with_handle(done).unwrap();
+
+            // I _thought_ that createHistoryStream would get messages greater than latests_seq,
+            // but maybe not?
+            let msg = create_hist_stream_msg(feed_id, latest_seq as u32 + 1, Some(10000));
+
+            let r = async move {
+                let (mut a_out, a_in) = out.send_duplex(BodyType::Json, msg).await?;
+                let packets = a_in.map(|p| p.body).collect::<Vec<_>>().await;
+
+                if packets.len() > 0 {
+                    eprintln!("got {} new messages from server", packets.len());
+
+                    let previous: Option<Vec<u8>> =
+                        db.get_entry_by_seq(&author, latest_seq).unwrap();
+
+                    //TODO add to the api of ssb-db
+                    par_validate_message_hash_chain_of_feed(&packets, previous.as_ref()).unwrap();
+                    eprintln!("validated messages");
+
+                    par_verify_messages(&packets, None).unwrap();
+                    eprintln!("verified messages");
+
+                    db.append_batch(&author, &packets).unwrap();
+
+                    eprintln!("appended {} new messages to db", packets.len());
+                } else {
+                    eprintln!("no new messages to append");
+                }
+
+                a_out
+                    .send_end(BodyType::Json, "true".bytes().collect())
+                    .await
+            };
+
+            let r = spawner.spawn_local_with_handle(r).unwrap();
+            pool.run_until(r).unwrap();
+            pool.run_until(done).unwrap();
+
+            Ok(())
+        }
+
         ("getfeed", Some(sub_m)) => {
             let secret_path = app_m.value_of("secret").unwrap();
             let feed_id = sub_m.value_of("feed").unwrap();
@@ -197,7 +357,8 @@ fn main() -> Result<(), Error> {
                 .write(true)
                 .create(true)
                 .truncate(true)
-                .open(&out_path).context(FlumeIo)?;
+                .open(&out_path)
+                .context(FlumeIo)?;
 
             let mut out_log = OffsetLog::<u32>::from_file(file).unwrap();
 
@@ -212,7 +373,9 @@ fn main() -> Result<(), Error> {
 
             let server_pk = PublicKey::from_slice(&base64::decode(peer_key).unwrap()).unwrap();
             let (box_r, box_w) = block_on(async {
-                let mut tcp = TcpStream::connect(&peer_addr).await.context(TcpConnection)?;
+                let mut tcp = TcpStream::connect(&peer_addr)
+                    .await
+                    .context(TcpConnection)?;
                 let o = client(&mut tcp, net_id, pk, sk, server_pk).await.unwrap();
 
                 let (tcp_r, tcp_w) = tcp.split();
@@ -226,16 +389,21 @@ fn main() -> Result<(), Error> {
             let (mut out, done) = mux(box_r, box_w, bumrpc);
             let done = spawner.spawn_local_with_handle(done).unwrap();
 
-            let msg = create_hist_stream_msg(feed_id, feed_seq, feed_limit);
+            let msg = create_hist_stream_msg(feed_id, feed_seq, Some(feed_limit));
 
             let r = async move {
                 let (mut a_out, a_in) = out.send_duplex(BodyType::Json, msg).await?;
-                a_in.for_each(|p| {
-                    // log_packet(&p);
-                    out_log.append(&p.body).unwrap();
-                    future::ready(())
-                }).await;
-                a_out.send_end(BodyType::Json, "true".bytes().collect()).await
+                let packets = a_in.map(|p| p.body).take(1).collect::<Vec<_>>().await;
+
+                println!("{:?}", packets);
+                //a_in.for_each(|p| {
+                //    // log_packet(&p);
+                //    out_log.append(&p.body).unwrap();
+                //    future::ready(())
+                //}).await;
+                a_out
+                    .send_end(BodyType::Json, "true".bytes().collect())
+                    .await
             };
 
             let r = spawner.spawn_local_with_handle(r).unwrap();
@@ -243,12 +411,11 @@ fn main() -> Result<(), Error> {
             pool.run_until(done).unwrap();
 
             Ok(())
-        },
+        }
 
         _ => {
             // println!("{}", app_m.usage());
             Ok(())
         }
     }
-
 }

--- a/rustle/src/main.rs
+++ b/rustle/src/main.rs
@@ -271,11 +271,6 @@ fn main() -> Result<(), Error> {
 
             let net_id = NetworkKey::SSB_MAIN_NET;
 
-            // ./rustle --secret-file ~/.testnet/secret getfeed --feed "@U5GvOKP/YUza9k53DSXxT0mk3PIrnyAmessvNfZl5E0=.ed25519" --addr "134.209.164.64:8008" --key "/1OZ3fUmzKcaKyuyw5ffFHcpStayDTco9zMN7R1ZE84="
-
-            // let key = "U5GvOKP/YUza9k53DSXxT0mk3PIrnyAmessvNfZl5E0=";
-            // let addr = "127.0.0.1:8008";
-
             let server_pk = PublicKey::from_slice(&base64::decode(peer_key).unwrap()).unwrap();
             let (box_r, box_w) = block_on(async {
                 let mut tcp = TcpStream::connect(&peer_addr)

--- a/ssb-multiformats/examples/main.rs
+++ b/ssb-multiformats/examples/main.rs
@@ -4,14 +4,13 @@ use std::fs::{self, File};
 use std::io::{self, prelude::*};
 use std::path::{Path, PathBuf};
 
-use ssb_multiformats::{multikey::Multikey, multihash::Multihash, multibox::Multibox};
+use ssb_multiformats::{multibox::Multibox, multihash::Multihash, multikey::Multikey};
 
 fn main() {
     handle_nays_key(Path::new("../multiformats-testdata/multikey/nay")).unwrap();
     handle_yays_key(Path::new("../multiformats-testdata/multikey/yay")).unwrap();
     handle_nays_hash(Path::new("../multiformats-testdata/multihash/nay")).unwrap();
     handle_yays_hash(Path::new("../multiformats-testdata/multihash/yay")).unwrap();
-
 
     let paths = fs::read_dir("./fuzz/corpus/roundtrip_box").unwrap();
 

--- a/ssb-multiformats/src/lib.rs
+++ b/ssb-multiformats/src/lib.rs
@@ -2,17 +2,18 @@
 // #![warn(missing_docs)]
 
 extern crate base64;
-extern crate serde;
 extern crate ring;
+extern crate serde;
 extern crate untrusted;
 
 #[cfg(test)]
-#[macro_use] extern crate matches;
+#[macro_use]
+extern crate matches;
 
-pub mod multikey;
-pub mod multihash;
 pub mod multibox;
 pub mod multifeed;
+pub mod multihash;
+pub mod multikey;
 
 ///////////////////////////////////////////////////////////////////////////////
 // A bunch of helper functions used throughout the crate for parsing legacy encodings.

--- a/ssb-multiformats/src/multihash.rs
+++ b/ssb-multiformats/src/multihash.rs
@@ -46,18 +46,16 @@ impl Multihash {
             s = tail;
             target = Target::Message;
         } else {
-            let tail = skip_prefix(s, b"&")
-                .ok_or_else(|| DecodeLegacyError::Sigil)?;
+            let tail = skip_prefix(s, b"&").ok_or_else(|| DecodeLegacyError::Sigil)?;
 
             s = tail;
             target = Target::Blob;
         }
 
-        let (data, suffix) = split_at_byte(s, 0x2E)
-            .ok_or_else(|| DecodeLegacyError::NoDot)?;
+        let (data, suffix) = split_at_byte(s, 0x2E).ok_or_else(|| DecodeLegacyError::NoDot)?;
 
-        let tail = skip_prefix(suffix, SHA256_SUFFIX) 
-            .ok_or_else(|| DecodeLegacyError::UnknownSuffix)?;
+        let tail =
+            skip_prefix(suffix, SHA256_SUFFIX).ok_or_else(|| DecodeLegacyError::UnknownSuffix)?;
 
         if data.len() != SHA256_BASE64_LEN {
             return Err(DecodeLegacyError::Sha256WrongSize);
@@ -117,7 +115,8 @@ impl Multihash {
 
 impl Serialize for Multihash {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: Serializer
+    where
+        S: Serializer,
     {
         serializer.serialize_str(&self.to_legacy_string())
     }
@@ -125,7 +124,8 @@ impl Serialize for Multihash {
 
 impl<'de> Deserialize<'de> for Multihash {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: Deserializer<'de>
+    where
+        D: Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
         Multihash::from_legacy(&s.as_bytes())
@@ -149,19 +149,14 @@ pub enum DecodeLegacyError {
     Sha256WrongSize,
 }
 
-
 impl fmt::Display for DecodeLegacyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             &DecodeLegacyError::Sigil => write!(f, "Invalid sigil"),
             &DecodeLegacyError::InvalidBase64(ref err) => write!(f, "{}", err),
             &DecodeLegacyError::NoDot => write!(f, "No dot"),
-            &DecodeLegacyError::UnknownSuffix => {
-                write!(f, "Unknown suffix")
-            }
-            &DecodeLegacyError::Sha256WrongSize => {
-                write!(f, "Data of wrong length")
-            }
+            &DecodeLegacyError::UnknownSuffix => write!(f, "Unknown suffix"),
+            &DecodeLegacyError::Sha256WrongSize => write!(f, "Data of wrong length"),
         }
     }
 }
@@ -177,12 +172,28 @@ const SSB_SHA256_ENCODED_LEN: usize = SHA256_BASE64_LEN + 9;
 
 #[test]
 fn test_from_legacy() {
-    assert!(Multihash::from_legacy(b"%MwjdLV95P7VqHfrgS49nScXsyIwJfL229e5OSKc+0rc=.sha256").is_ok());
-    assert!(Multihash::from_legacy(b"&MwjdLV95P7VqHfrgS49nScXsyIwJfL229e5OSKc+0rc=.sha256").is_ok());
-    assert!(Multihash::from_legacy(b"%MwjdLV95P7VqHfrgS49nScXsyIwJfL229e5OSKc+0rd=.sha256").is_err());
-    assert!(Multihash::from_legacy(b"@MwjdLV95P7VqHfrgS49nScXsyIwJfL229e5OSKc+0rc=.sha256").is_err());
-    assert!(Multihash::from_legacy(b"%MwjdLV95P7VqHfrgS49nScXsyIwJfL229e5OSKc+0rc=.tha256").is_err());
-    assert!(Multihash::from_legacy(b"%MwjdLV95P7VqHfrgS49nScXsyIwJfL229e5OSKc+0rc=sha256").is_err());
-    assert!(Multihash::from_legacy(b"%MwjdLV95P7VqHfrgS49nScXsyIwJfL229e5OSKc+0rc.sha256").is_err());
-    assert!(Multihash::from_legacy(b"%MwjdLV95P7VqHfrgS49nScXsyIwJfL229e5OSKc+0rc==.sha256").is_err());
+    assert!(
+        Multihash::from_legacy(b"%MwjdLV95P7VqHfrgS49nScXsyIwJfL229e5OSKc+0rc=.sha256").is_ok()
+    );
+    assert!(
+        Multihash::from_legacy(b"&MwjdLV95P7VqHfrgS49nScXsyIwJfL229e5OSKc+0rc=.sha256").is_ok()
+    );
+    assert!(
+        Multihash::from_legacy(b"%MwjdLV95P7VqHfrgS49nScXsyIwJfL229e5OSKc+0rd=.sha256").is_err()
+    );
+    assert!(
+        Multihash::from_legacy(b"@MwjdLV95P7VqHfrgS49nScXsyIwJfL229e5OSKc+0rc=.sha256").is_err()
+    );
+    assert!(
+        Multihash::from_legacy(b"%MwjdLV95P7VqHfrgS49nScXsyIwJfL229e5OSKc+0rc=.tha256").is_err()
+    );
+    assert!(
+        Multihash::from_legacy(b"%MwjdLV95P7VqHfrgS49nScXsyIwJfL229e5OSKc+0rc=sha256").is_err()
+    );
+    assert!(
+        Multihash::from_legacy(b"%MwjdLV95P7VqHfrgS49nScXsyIwJfL229e5OSKc+0rc.sha256").is_err()
+    );
+    assert!(
+        Multihash::from_legacy(b"%MwjdLV95P7VqHfrgS49nScXsyIwJfL229e5OSKc+0rc==.sha256").is_err()
+    );
 }

--- a/ssb-packetstream/Cargo.toml
+++ b/ssb-packetstream/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 keywords = ["packet-stream", "protocol", "ssb", "scuttlebutt"]
 
 [dependencies]
+async-trait = "0.1.18"
 byteorder = "1.3.1"
 futures = "0.3.1"
 snafu = { version = "0.6.0", features = ["futures"] }

--- a/ssb-packetstream/src/lib.rs
+++ b/ssb-packetstream/src/lib.rs
@@ -3,10 +3,10 @@ mod packet;
 mod sink;
 mod stream;
 
+pub use mux::*;
 pub use packet::*;
 pub use sink::*;
 pub use stream::*;
-pub use mux::*;
 
 use core::future::Future;
 use core::pin::Pin;
@@ -19,8 +19,8 @@ mod tests {
     use byteorder::{BigEndian, ByteOrder};
     use futures::executor::block_on;
     use futures::io::AsyncReadExt;
-    use futures::{future::join, stream::iter, SinkExt, TryStreamExt};
     use futures::stream::StreamExt;
+    use futures::{future::join, stream::iter, SinkExt, TryStreamExt};
 
     #[test]
     fn encode() {
@@ -96,9 +96,7 @@ mod tests {
         };
 
         let recv = async {
-            let r: Vec<Packet> = stream
-                .try_collect()
-                .await.unwrap();
+            let r: Vec<Packet> = stream.try_collect().await.unwrap();
             r
         };
 
@@ -180,5 +178,4 @@ mod tests {
             assert_eq!(n, 0);
         });
     }
-
 }

--- a/ssb-packetstream/src/mux.rs
+++ b/ssb-packetstream/src/mux.rs
@@ -1,60 +1,45 @@
 use crate::*;
-use futures::channel::mpsc::{self, Receiver, Sender, SendError};
+use futures::channel::mpsc::{self, Receiver, SendError, Sender};
 use futures::future::{join, FutureExt};
-use futures::stream::{Stream, StreamExt, TryStreamExt};
-use futures::sink::SinkExt;
 use futures::io::{AsyncRead, AsyncWrite};
+use futures::sink::SinkExt;
+use futures::stream::{Stream, StreamExt, TryStreamExt};
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
 use std::error;
+use std::sync::{Arc, Mutex};
 
 use snafu::{futures::TryStreamExt as SnafuTSE, ResultExt, Snafu};
 
 #[derive(Debug, Snafu)]
 pub enum Error<HandlerErrorT>
-where HandlerErrorT: std::error::Error + 'static
+where
+    HandlerErrorT: std::error::Error + 'static,
 {
     #[snafu(display("PacketSink failure: {}", source))]
-    Outgoing {
-        source: sink::Error
-    },
+    Outgoing { source: sink::Error },
 
     #[snafu(display("PacketStream failure: {}", source))]
-    Incoming {
-        source: stream::Error
-    },
+    Incoming { source: stream::Error },
 
     #[snafu(display("Sub stream failure: {}", source))]
-    SubStream {
-        source: SendError
-    },
+    SubStream { source: SendError },
 
     #[snafu(display("Mux packet handler error: {}", source))]
-    Handler {
-        source: HandlerErrorT
-    },
+    Handler { source: HandlerErrorT },
 }
 
 #[derive(Debug, Snafu)]
 pub enum ChildError {
     // TODO: better name, useful context, better messages
-
     #[snafu(display("Error sending packet: {}", source))]
-    Send {
-        source: SendError
-    },
+    Send { source: SendError },
 
     #[snafu(display("Error sending stream end packet: {}", source))]
-    SendEnd {
-        source: SendError
-    },
+    SendEnd { source: SendError },
 
     #[snafu(display("Error sending stream: {}", source))]
-    SendAll {
-        source: SendError
-    },
+    SendAll { source: SendError },
 }
-
 
 // Packets with id < 0 are responses to one of our
 // outgoing requests.
@@ -89,14 +74,17 @@ impl MuxSender {
         // TODO: check js behavior
         self._id = match self._id.checked_add(1) {
             None => 1,
-            Some(i) => i
+            Some(i) => i,
         };
         id
     }
 
     fn new_response_stream(&mut self, request_id: i32) -> ChildStream {
         let (in_sink, in_stream) = channel();
-        self.response_sinks.lock().unwrap().insert(-request_id, in_sink);
+        self.response_sinks
+            .lock()
+            .unwrap()
+            .insert(-request_id, in_sink);
         in_stream
     }
 
@@ -106,7 +94,11 @@ impl MuxSender {
 }
 
 impl MuxSender {
-    pub async fn send(&mut self, body_type: BodyType, body: Vec<u8>) -> Result<ChildStream, ChildError> {
+    pub async fn send(
+        &mut self,
+        body_type: BodyType,
+        body: Vec<u8>,
+    ) -> Result<ChildStream, ChildError> {
         let out_id = self.next_id();
         let in_stream = self.new_response_stream(out_id);
 
@@ -115,7 +107,11 @@ impl MuxSender {
         Ok(in_stream)
     }
 
-    pub async fn send_duplex(&mut self, body_type: BodyType, body: Vec<u8>) -> Result<(MuxChildSender, ChildStream), ChildError> {
+    pub async fn send_duplex(
+        &mut self,
+        body_type: BodyType,
+        body: Vec<u8>,
+    ) -> Result<(MuxChildSender, ChildStream), ChildError> {
         let out_id = self.next_id();
         let in_stream = self.new_response_stream(out_id);
 
@@ -152,23 +148,32 @@ impl MuxChildSender {
     }
 
     pub async fn send(&mut self, body_type: BodyType, body: Vec<u8>) -> Result<(), ChildError> {
-        self.send_packet(Packet::new(self.is_stream,
-                                     IsEnd::No,
-                                     body_type,
-                                     self.id,
-                                     body)).await.context(Send)
+        self.send_packet(Packet::new(
+            self.is_stream,
+            IsEnd::No,
+            body_type,
+            self.id,
+            body,
+        ))
+        .await
+        .context(Send)
     }
 
     pub async fn send_end(&mut self, body_type: BodyType, body: Vec<u8>) -> Result<(), ChildError> {
-        self.send_packet(Packet::new(self.is_stream,
-                                     IsEnd::Yes,
-                                     body_type,
-                                     self.id,
-                                     body)).await.context(SendEnd)
+        self.send_packet(Packet::new(
+            self.is_stream,
+            IsEnd::Yes,
+            body_type,
+            self.id,
+            body,
+        ))
+        .await
+        .context(SendEnd)
     }
 
     pub async fn send_all<S>(&mut self, s: S) -> Result<(), ChildError>
-    where S: Stream<Item = (BodyType, Vec<u8>)> + Unpin,
+    where
+        S: Stream<Item = (BodyType, Vec<u8>)> + Unpin,
     {
         let id = self.id;
         let is_stream = self.is_stream;
@@ -194,8 +199,11 @@ impl MuxChildSender {
 //   - &mut response_sink_map
 //   - out_sender (owned clone)
 
-pub fn mux<R, W, H, E, T>(r: R, w: W, handler: H)
-                          -> (MuxSender, impl Future<Output = Result<(), Error<E>>>)
+pub fn mux<R, W, H, E, T>(
+    r: R,
+    w: W,
+    handler: H,
+) -> (MuxSender, impl Future<Output = Result<(), Error<E>>>)
 where
     R: AsyncRead + Unpin + 'static,
     W: AsyncWrite + Unpin + 'static,
@@ -203,10 +211,13 @@ where
     T: Future<Output = Result<(), E>>,
     E: error::Error + 'static,
 {
-
     let (shared_sender, recv) = channel();
     let out_done = async move {
-        let r = recv.map(|p| Ok(p)).forward(PacketSink::new(w)).await.context(Outgoing);
+        let r = recv
+            .map(|p| Ok(p))
+            .forward(PacketSink::new(w))
+            .await
+            .context(Outgoing);
         // eprintln!("FORWARDED ALL");
         r
     };
@@ -220,45 +231,51 @@ where
         let in_stream = PacketStream::new(r);
 
         const OPEN_STREAMS_LIMIT: usize = 128;
-        let in_done = in_stream.context(Incoming)
-            .try_for_each_concurrent(OPEN_STREAMS_LIMIT, |p: Packet| async {
-                if p.id < 0 {
-                    let mut response_sinks = response_sinks.lock().unwrap();
-                    if let Some(ref mut sink) = response_sinks.get_mut(&p.id) {
-                        if p.is_stream() && p.is_end() {
-                            sink.close().await.context(SubStream)
+        let in_done =
+            in_stream
+                .context(Incoming)
+                .try_for_each_concurrent(OPEN_STREAMS_LIMIT, |p: Packet| {
+                    async {
+                        if p.id < 0 {
+                            let mut response_sinks = response_sinks.lock().unwrap();
+                            if let Some(ref mut sink) = response_sinks.get_mut(&p.id) {
+                                if p.is_stream() && p.is_end() {
+                                    sink.close().await.context(SubStream)
+                                } else {
+                                    sink.send(p).await.context(SubStream)
+                                }
+                            } else {
+                                eprintln!("Unhandled response packet: {:?}", p);
+                                Ok(())
+                            }
                         } else {
-                            sink.send(p).await.context(SubStream)
+                            let mut maybe_sink = {
+                                let csinks = continuation_sinks.lock().unwrap();
+                                csinks.get(&p.id).map(|s| s.clone())
+                            };
+                            if let Some(ref mut sink) = maybe_sink {
+                                if p.is_stream() && p.is_end() {
+                                    sink.close().await.context(SubStream)
+                                } else {
+                                    sink.send(p).await.context(SubStream)
+                                }
+                            } else if p.is_stream() {
+                                let (inn_sink, inn) = channel();
+                                {
+                                    let mut csinks = continuation_sinks.lock().unwrap();
+                                    csinks.insert(p.id, inn_sink);
+                                }
+                                let sender =
+                                    MuxChildSender::new(-p.id, p.stream, shared_sender.clone());
+                                handler(p, sender, Some(inn)).await.context(Handler)
+                            } else {
+                                let sender =
+                                    MuxChildSender::new(-p.id, p.stream, shared_sender.clone());
+                                handler(p, sender, None).await.context(Handler)
+                            }
                         }
-                    } else {
-                        eprintln!("Unhandled response packet: {:?}", p);
-                        Ok(())
                     }
-                } else {
-                    let mut maybe_sink = {
-                        let csinks = continuation_sinks.lock().unwrap();
-                        csinks.get(&p.id).map(|s| s.clone())
-                    };
-                    if let Some(ref mut sink) = maybe_sink {
-                        if p.is_stream() && p.is_end() {
-                            sink.close().await.context(SubStream)
-                        } else {
-                            sink.send(p).await.context(SubStream)
-                        }
-                    } else if p.is_stream() {
-                        let (inn_sink, inn) = channel();
-                        {
-                            let mut csinks = continuation_sinks.lock().unwrap();
-                            csinks.insert(p.id, inn_sink);
-                        }
-                        let sender = MuxChildSender::new(-p.id, p.stream, shared_sender.clone());
-                        handler(p, sender, Some(inn)).await.context(Handler)
-                    } else {
-                        let sender = MuxChildSender::new(-p.id, p.stream, shared_sender.clone());
-                        handler(p, sender, None).await.context(Handler)
-                    }
-                }
-            });
+                });
         let (in_r, out_r) = join(in_done, out_done).await;
         in_r.or(out_r)
     };
@@ -269,45 +286,42 @@ fn channel<T>() -> (Sender<T>, Receiver<T>) {
     mpsc::channel::<T>(128) // Arbitrary
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use futures::executor::LocalPool;
-    use futures::task::LocalSpawnExt;
     use futures::stream::StreamExt;
+    use futures::task::LocalSpawnExt;
     use snafu::{ResultExt, Snafu};
-
 
     #[derive(Debug, Snafu)]
     enum RpcError {
         #[snafu(display("Failed to send Reverse response: {}", source))]
-        Reverse {
-            source: ChildError
-        },
+        Reverse { source: ChildError },
 
         #[snafu(display("Failed to send Double (non-stream) response: {}", source))]
-        DoubleBatch {
-            source: ChildError
-        },
+        DoubleBatch { source: ChildError },
 
         #[snafu(display("Failed to send Double (stream) response: {}", source))]
-        DoubleStream {
-            source: ChildError
-        },
+        DoubleStream { source: ChildError },
     }
 
-    async fn cool_rpc(p: Packet, mut out: MuxChildSender, inn: Option<Receiver<Packet>>)
-                      -> Result<(), RpcError> {
-
+    async fn cool_rpc(
+        p: Packet,
+        mut out: MuxChildSender,
+        inn: Option<Receiver<Packet>>,
+    ) -> Result<(), RpcError> {
         let (method, args) = p.body.split_first().unwrap();
 
         match *method as char {
-            'R' => { // Reverse
+            'R' => {
+                // Reverse
                 out.send(BodyType::Binary, args.iter().rev().map(|u| *u).collect())
-                    .await.context(Reverse)
-            },
-            'D' => { // Double each arg
+                    .await
+                    .context(Reverse)
+            }
+            'D' => {
+                // Double each arg
                 if p.is_stream() {
                     let mut inn = inn.unwrap().map(|argp: Packet| {
                         let x = argp.body.first().unwrap();
@@ -315,11 +329,11 @@ mod tests {
                     });
                     out.send_all(&mut inn).await.context(DoubleStream)
                 } else {
-                    out.send(BodyType::Binary,
-                             args.iter().map(|n| n * 2).collect())
-                        .await.context(DoubleBatch)
+                    out.send(BodyType::Binary, args.iter().map(|n| n * 2).collect())
+                        .await
+                        .context(DoubleBatch)
                 }
-            },
+            }
             _ => {
                 eprintln!("CoolRPC unrecognized packet: {:?}", p);
                 Ok(())
@@ -342,77 +356,96 @@ mod tests {
         let mut client_in = PacketStream::new(client_r);
         let mut client_out = PacketSink::new(client_w);
 
-        let reply = spawner.spawn_local_with_handle(async move {
-            // Call Reverse procedure
-            client_out.send(Packet::new(
-                IsStream::No,
-                IsEnd::No,
-                BodyType::Binary,
-                1,
-                vec!['R' as u8, 1, 2, 3, 4, 5],
-            )).await.unwrap();
+        let reply = spawner
+            .spawn_local_with_handle(async move {
+                // Call Reverse procedure
+                client_out
+                    .send(Packet::new(
+                        IsStream::No,
+                        IsEnd::No,
+                        BodyType::Binary,
+                        1,
+                        vec!['R' as u8, 1, 2, 3, 4, 5],
+                    ))
+                    .await
+                    .unwrap();
 
-            let p = client_in.try_next().await.unwrap().unwrap();
-            assert_eq!(p.id, -1);
-            assert_eq!(p.body, &[5, 4, 3, 2, 1]);
+                let p = client_in.try_next().await.unwrap().unwrap();
+                assert_eq!(p.id, -1);
+                assert_eq!(p.body, &[5, 4, 3, 2, 1]);
 
-            // Call Double (non-stream) procedure
-            client_out.send(Packet::new(
-                IsStream::No,
-                IsEnd::No,
-                BodyType::Binary,
-                2,
-                vec!['D' as u8, 0, 5, 10, 20, 30],
-            )).await.unwrap();
+                // Call Double (non-stream) procedure
+                client_out
+                    .send(Packet::new(
+                        IsStream::No,
+                        IsEnd::No,
+                        BodyType::Binary,
+                        2,
+                        vec!['D' as u8, 0, 5, 10, 20, 30],
+                    ))
+                    .await
+                    .unwrap();
 
-            let p = client_in.try_next().await.unwrap().unwrap();
-            assert_eq!(p.id, -2);
-            assert_eq!(p.body, &[0, 10, 20, 40, 60]);
+                let p = client_in.try_next().await.unwrap().unwrap();
+                assert_eq!(p.id, -2);
+                assert_eq!(p.body, &[0, 10, 20, 40, 60]);
 
-            // Call Double (stream) procedure
-            client_out.send(Packet::new(
-                IsStream::Yes,
-                IsEnd::No,
-                BodyType::Binary,
-                3,
-                vec!['D' as u8],
-            )).await.unwrap();
-            client_out.send(Packet::new(
-                IsStream::Yes,
-                IsEnd::No,
-                BodyType::Binary,
-                3,
-                vec![6],
-            )).await.unwrap();
+                // Call Double (stream) procedure
+                client_out
+                    .send(Packet::new(
+                        IsStream::Yes,
+                        IsEnd::No,
+                        BodyType::Binary,
+                        3,
+                        vec!['D' as u8],
+                    ))
+                    .await
+                    .unwrap();
+                client_out
+                    .send(Packet::new(
+                        IsStream::Yes,
+                        IsEnd::No,
+                        BodyType::Binary,
+                        3,
+                        vec![6],
+                    ))
+                    .await
+                    .unwrap();
 
-            let p = client_in.try_next().await.unwrap().unwrap();
-            assert_eq!(p.id, -3);
-            assert_eq!(p.body, &[12]);
+                let p = client_in.try_next().await.unwrap().unwrap();
+                assert_eq!(p.id, -3);
+                assert_eq!(p.body, &[12]);
 
-            client_out.send(Packet::new(
-                IsStream::Yes,
-                IsEnd::No,
-                BodyType::Binary,
-                3,
-                vec![8],
-            )).await.unwrap();
-            client_out.send(Packet::new(
-                IsStream::Yes,
-                IsEnd::No,
-                BodyType::Binary,
-                3,
-                vec![10],
-            )).await.unwrap();
+                client_out
+                    .send(Packet::new(
+                        IsStream::Yes,
+                        IsEnd::No,
+                        BodyType::Binary,
+                        3,
+                        vec![8],
+                    ))
+                    .await
+                    .unwrap();
+                client_out
+                    .send(Packet::new(
+                        IsStream::Yes,
+                        IsEnd::No,
+                        BodyType::Binary,
+                        3,
+                        vec![10],
+                    ))
+                    .await
+                    .unwrap();
 
-            let p = client_in.try_next().await.unwrap().unwrap();
-            assert_eq!(p.id, -3);
-            assert_eq!(p.body, &[16]);
+                let p = client_in.try_next().await.unwrap().unwrap();
+                assert_eq!(p.id, -3);
+                assert_eq!(p.body, &[16]);
 
-            let p = client_in.try_next().await.unwrap().unwrap();
-            assert_eq!(p.id, -3);
-            assert_eq!(p.body, &[20]);
-
-        }).unwrap();
+                let p = client_in.try_next().await.unwrap().unwrap();
+                assert_eq!(p.id, -3);
+                assert_eq!(p.body, &[20]);
+            })
+            .unwrap();
 
         pool.run_until(reply);
 
@@ -421,13 +454,7 @@ mod tests {
     }
 
     fn sb_packet(b: u8, id: i32) -> Packet {
-        Packet::new(
-            IsStream::Yes,
-            IsEnd::No,
-            BodyType::Binary,
-            id,
-            vec![b],
-        )
+        Packet::new(IsStream::Yes, IsEnd::No, BodyType::Binary, id, vec![b])
     }
 
     #[test]
@@ -444,69 +471,75 @@ mod tests {
         let _server_done = spawner.spawn_local_with_handle(server_done).unwrap();
         let _client_done = spawner.spawn_local_with_handle(client_done).unwrap();
 
-        let reply = spawner.spawn_local_with_handle(async move {
-            // Call Reverse procedure
-            let rev_id = 1;
-            let mut rev_response = client_out.send(BodyType::Binary,
-                                                   vec!['R' as u8, 1, 2, 3, 4, 5])
-                .await.unwrap();
+        let reply = spawner
+            .spawn_local_with_handle(async move {
+                // Call Reverse procedure
+                let rev_id = 1;
+                let mut rev_response = client_out
+                    .send(BodyType::Binary, vec!['R' as u8, 1, 2, 3, 4, 5])
+                    .await
+                    .unwrap();
 
-            // Call Double (stream) procedure
-            let a_id = 2;
-            let (mut a_out, mut a_in) = client_out
-                .send_duplex(BodyType::Binary, vec!['D' as u8])
-                .await.unwrap();
+                // Call Double (stream) procedure
+                let a_id = 2;
+                let (mut a_out, mut a_in) = client_out
+                    .send_duplex(BodyType::Binary, vec!['D' as u8])
+                    .await
+                    .unwrap();
 
-            a_out.send(BodyType::Binary, vec![6]).await.unwrap();
+                a_out.send(BodyType::Binary, vec![6]).await.unwrap();
 
-            let p = a_in.next().await.unwrap();
-            assert_eq!(p.id, -a_id);
-            assert_eq!(p.body, &[12]);
+                let p = a_in.next().await.unwrap();
+                assert_eq!(p.id, -a_id);
+                assert_eq!(p.body, &[12]);
 
-            // Check rev response
-            let p = rev_response.next().await.unwrap();
-            assert_eq!(p.id, -rev_id);
-            assert_eq!(p.body, &[5, 4, 3, 2, 1]);
+                // Check rev response
+                let p = rev_response.next().await.unwrap();
+                assert_eq!(p.id, -rev_id);
+                assert_eq!(p.body, &[5, 4, 3, 2, 1]);
 
-            a_out.send(BodyType::Binary, vec![8]).await.unwrap();
+                a_out.send(BodyType::Binary, vec![8]).await.unwrap();
 
-            let (mut dub3_out, mut dub3_in) = server_out
-                .send_duplex(BodyType::Binary, vec!['D' as u8])
-                .await.unwrap();
-            dub3_out.send(BodyType::Binary, vec![30]).await.unwrap();
+                let (mut dub3_out, mut dub3_in) = server_out
+                    .send_duplex(BodyType::Binary, vec!['D' as u8])
+                    .await
+                    .unwrap();
+                dub3_out.send(BodyType::Binary, vec![30]).await.unwrap();
 
-            let b_id = 3;
-            let (mut b_out, mut b_in) = client_out
-                .send_duplex(BodyType::Binary, vec!['D' as u8])
-                .await.unwrap();
-            b_out.send(BodyType::Binary, vec![44]).await.unwrap();
-            a_out.send(BodyType::Binary, vec![10]).await.unwrap();
-            dub3_out.send(BodyType::Binary, vec![30]).await.unwrap();
+                let b_id = 3;
+                let (mut b_out, mut b_in) = client_out
+                    .send_duplex(BodyType::Binary, vec!['D' as u8])
+                    .await
+                    .unwrap();
+                b_out.send(BodyType::Binary, vec![44]).await.unwrap();
+                a_out.send(BodyType::Binary, vec![10]).await.unwrap();
+                dub3_out.send(BodyType::Binary, vec![30]).await.unwrap();
 
-            let p = dub3_in.next().await.unwrap();
-            assert_eq!(p.id, -1);
-            assert_eq!(p.body, &[60]);
+                let p = dub3_in.next().await.unwrap();
+                assert_eq!(p.id, -1);
+                assert_eq!(p.body, &[60]);
 
-            let p = b_in.next().await.unwrap();
-            assert_eq!(p.id, -b_id);
-            assert_eq!(p.body, &[88]);
+                let p = b_in.next().await.unwrap();
+                assert_eq!(p.id, -b_id);
+                assert_eq!(p.body, &[88]);
 
-            let p = a_in.next().await.unwrap();
-            assert_eq!(p.id, -a_id);
-            assert_eq!(p.body, &[16]);
+                let p = a_in.next().await.unwrap();
+                assert_eq!(p.id, -a_id);
+                assert_eq!(p.body, &[16]);
 
-            b_out.send(BodyType::Binary, vec![100]).await.unwrap();
+                b_out.send(BodyType::Binary, vec![100]).await.unwrap();
 
-            let p = b_in.next().await.unwrap();
-            assert_eq!(p.id, -b_id);
-            assert_eq!(p.body, &[200]);
+                let p = b_in.next().await.unwrap();
+                assert_eq!(p.id, -b_id);
+                assert_eq!(p.body, &[200]);
 
-            let p = a_in.next().await.unwrap();
-            assert_eq!(p.id, -a_id);
-            assert_eq!(p.body, &[20]);
+                let p = a_in.next().await.unwrap();
+                assert_eq!(p.id, -a_id);
+                assert_eq!(p.body, &[20]);
 
-            server_out.close();
-        }).unwrap();
+                server_out.close();
+            })
+            .unwrap();
 
         pool.run_until(reply);
 
@@ -514,5 +547,4 @@ mod tests {
         // let p = pool.run_until(server_done);
         // let p = pool.run_until(client_done);
     }
-
 }

--- a/ssb-packetstream/src/mux.rs
+++ b/ssb-packetstream/src/mux.rs
@@ -1,6 +1,6 @@
 use crate::*;
 use futures::channel::mpsc::{self, Receiver, SendError, Sender};
-use futures::future::{join, FutureExt, TryFuture, TryFutureExt};
+use futures::future::{join, FutureExt};
 use futures::io::{AsyncRead, AsyncWrite};
 use futures::sink::SinkExt;
 use futures::stream::{Stream, StreamExt, TryStreamExt};
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::error;
 use std::sync::{Arc, Mutex};
 
-use snafu::{futures::TryStreamExt as SnafuTSE, futures::TryFutureExt as SnafuTFE,  ResultExt, Snafu};
+use snafu::{futures::TryStreamExt as SnafuTSE, ResultExt, Snafu};
 
 #[derive(Debug, Snafu)]
 pub enum Error<HandlerErrorT>
@@ -25,7 +25,7 @@ where
     SubStream { source: SendError },
 
     #[snafu(display("Mux packet handler error: {}", source))]
-    HandlerError { source: HandlerErrorT },
+    Handler { source: HandlerErrorT },
 }
 
 #[derive(Debug, Snafu)]
@@ -199,13 +199,6 @@ impl MuxChildSender {
 //   - &mut response_sink_map
 //   - out_sender (owned clone)
 
-pub trait Handler
-where
-{
-    type T;
-    fn handle(&self, packet: Packet, sender: MuxChildSender, receiver: Option<Receiver<Packet>>) -> Self::T;
-}
-
 pub fn mux<R, W, H, E, T>(
     r: R,
     w: W,
@@ -214,7 +207,7 @@ pub fn mux<R, W, H, E, T>(
 where
     R: AsyncRead + Unpin + 'static,
     W: AsyncWrite + Unpin + 'static,
-    H: Handler<T=T>,
+    H: Fn(Packet, MuxChildSender, Option<Receiver<Packet>>) -> T,
     T: Future<Output = Result<(), E>>,
     E: error::Error + 'static,
 {
@@ -274,13 +267,11 @@ where
                                 }
                                 let sender =
                                     MuxChildSender::new(-p.id, p.stream, shared_sender.clone());
-                                handler.handle(p, sender, Some(inn)).await.context(HandlerError)
+                                handler(p, sender, Some(inn)).await.context(Handler)
                             } else {
                                 let sender =
                                     MuxChildSender::new(-p.id, p.stream, shared_sender.clone());
-                                handler.handle(p, sender, None).await.context(HandlerError)
-                            
-
+                                handler(p, sender, None).await.context(Handler)
                             }
                         }
                     }
@@ -315,46 +306,40 @@ mod tests {
         DoubleStream { source: ChildError },
     }
 
-    struct CoolRPC{}
-    impl<T, E> Handler<T,E> for CoolRPC{
-        async fn handle(
-            &self,
-            p: Packet,
-            mut out: MuxChildSender,
-            inn: Option<Receiver<Packet>>,
-        ) -> Result<(), RpcError> {
-            let (method, args) = p.body.split_first().unwrap();
+    async fn cool_rpc(
+        p: Packet,
+        mut out: MuxChildSender,
+        inn: Option<Receiver<Packet>>,
+    ) -> Result<(), RpcError> {
+        let (method, args) = p.body.split_first().unwrap();
 
-            match *method as char {
-                'R' => {
-                    // Reverse
-                    out.send(BodyType::Binary, args.iter().rev().map(|u| *u).collect())
+        match *method as char {
+            'R' => {
+                // Reverse
+                out.send(BodyType::Binary, args.iter().rev().map(|u| *u).collect())
+                    .await
+                    .context(Reverse)
+            }
+            'D' => {
+                // Double each arg
+                if p.is_stream() {
+                    let mut inn = inn.unwrap().map(|argp: Packet| {
+                        let x = argp.body.first().unwrap();
+                        (BodyType::Binary, vec![x * 2])
+                    });
+                    out.send_all(&mut inn).await.context(DoubleStream)
+                } else {
+                    out.send(BodyType::Binary, args.iter().map(|n| n * 2).collect())
                         .await
-                        .context(Reverse)
-                }
-                'D' => {
-                    // Double each arg
-                    if p.is_stream() {
-                        let mut inn = inn.unwrap().map(|argp: Packet| {
-                            let x = argp.body.first().unwrap();
-                            (BodyType::Binary, vec![x * 2])
-                        });
-                        out.send_all(&mut inn).await.context(DoubleStream)
-                    } else {
-                        out.send(BodyType::Binary, args.iter().map(|n| n * 2).collect())
-                            .await
-                            .context(DoubleBatch)
-                    }
-                }
-                _ => {
-                    eprintln!("CoolRPC unrecognized packet: {:?}", p);
-                    Ok(())
+                        .context(DoubleBatch)
                 }
             }
+            _ => {
+                eprintln!("CoolRPC unrecognized packet: {:?}", p);
+                Ok(())
+            }
         }
-
     }
-
 
     #[test]
     fn mux_one_way() {

--- a/ssb-packetstream/src/sink.rs
+++ b/ssb-packetstream/src/sink.rs
@@ -12,26 +12,16 @@ use snafu::{ResultExt, Snafu};
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("Failed to send goodbye packet: {}", source))]
-    SendGoodbye {
-        source: std::io::Error
-    },
+    SendGoodbye { source: std::io::Error },
 
     #[snafu(display("Failed to send packet: {}", source))]
-    Send {
-        source: std::io::Error
-    },
+    Send { source: std::io::Error },
 
     #[snafu(display("Failed to flush sink: {}", source))]
-    Flush {
-        source: std::io::Error
-    },
+    Flush { source: std::io::Error },
 
     #[snafu(display("Error while closing sink: {}", source))]
-    Close {
-        source: std::io::Error
-    },
-
-
+    Close { source: std::io::Error },
 }
 
 async fn send<W>(mut w: W, msg: Packet) -> (W, Result<(), Error>)
@@ -51,7 +41,7 @@ where
     W: AsyncWrite + Unpin + 'static,
 {
     let r = w.write_all(&[0; 9]).await;
-    (w, r.map(|_| ()).context(SendGoodbye{}))
+    (w, r.map(|_| ()).context(SendGoodbye {}))
 }
 
 /// #Examples

--- a/ssb-packetstream/src/stream.rs
+++ b/ssb-packetstream/src/stream.rs
@@ -12,20 +12,17 @@ use snafu::{ensure, ResultExt, Snafu};
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("Failed to receive packet: {}", source))]
-    Recv {
-        source: std::io::Error
-    },
+    Recv { source: std::io::Error },
 
     #[snafu(display("IO error while reading packet header: {}", source))]
-    Header {
-        source: std::io::Error
-    },
+    Header { source: std::io::Error },
 
-    #[snafu(display("IO error while reading packet body. Body size: {}. Error: {}", size, source))]
-    Body {
-        size: usize,
-        source: std::io::Error
-    },
+    #[snafu(display(
+        "IO error while reading packet body. Body size: {}. Error: {}",
+        size,
+        source
+    ))]
+    Body { size: usize, source: std::io::Error },
 
     #[snafu(display("PacketStream underlying reader closed without goodbye"))]
     NoGoodbye {},
@@ -50,7 +47,9 @@ where
     let id = BigEndian::read_i32(&head[5..]);
 
     let mut body = vec![0; body_len];
-    r.read_exact(&mut body).await.context(Body{size: body_len})?;
+    r.read_exact(&mut body)
+        .await
+        .context(Body { size: body_len })?;
 
     Ok(Some(Packet::new(
         head[0].into(),


### PR DESCRIPTION
# :tada: World's first rusty replication :tada:

## About

In short, this PR should let you try out:

1. (from rust) publish a new message.
2. (from rust ) connect to a (modded) js ssb-server that requests your feed and replicate it to js.
3. (from js) publish a reply to the rusty message
4. (from rust) connect to the js ssb-server and replicate the js server's feed.
5. (from rust) call `createHistoryStream` for the js feed and see the js reply in the console.

## Setup

We want to force the js server to always request the feed of the rust bot. 
- Clone and npm install ssb-server
- In the `node_modules/ssb-replicate` folder, edit `legacy.js`, line 351 to look like:
```js
    function fallback () {
      //if we are not configured to use EBT, then fallback to createHistoryStream
      if(replicate_self) return
      replicate_self = true
      replicate({id: "<KEY_OF_RUST_ID>", sequence: 0})
      replicate({id: ssbServer.id, sequence: toSend[ssbServer.id] || 0})
    }
```

We want to switch off `ebt` as well.
- Edit `bin.js` in the top level of `ssb-server` and comment out line 61 eg.
```js
    //.use(require('ssb-ebt'))
```

Make a secret file for the rust code to use that is different from the js-bot.

## One other important caveat

The path to the offset file and sqlite file are hard coded to be `/tmp/ssb-db.offset` and `/tmp/ssb-db.sqlite3` in the `handleReplicationRequests` command. That means **you must use those same paths for the other commands.**

I need to hard code them otherwise we get borrow checker errors because of the async lambda function around line 365.

## Let's do it!

Publish our message:
```sh
./target/release/rustle --secret-file <path-to-secret> publish --dbpath /tmp/ssb-db.sqlite3 --offsetpath /tmp/ssb-db.offset --content '{"type":"post", "text": "hello from RUST!"}'
```

and you should see something like:
```
published a new message!
{
  "key": "%sdWbyCRzELsK70UTgKdWBDeVx6LHt680AzrI39tE5Ns=.sha256",
  "value": {
    "previous": "%iT6lKuNaTgcixW4LrG6u0L32i3pnSfDw2CYmcd2JVN4=.sha256",
    "author": "@SpDxZ/N2pG0NemSXhPbzbEy4KUH3028+z83FtbqyTEY=.ed25519",
    "sequence": 2,
    "timestamp": 0,
    "hash": "sha256",
    "content": {
      "text": "hello from RUST!",
      "type": "post"
    },
    "signature": "S5062Za77eF11HzAp1lW14aQdVIO6T+xdvS/df+d7MFP8UPficXi+wSQ29rM4kVY6f0OcfwDtv5us1ejGSaUDw==.sig.ed25519"
  }
}
```

Get the js ssb-server to replicate us:

With the modded ssb-server running.

```sh
./target/release/rustle --secret-file <path-to-secret> handleReplicationRequests --key <key-of-js-ssb-server-without-@-or-.ed25519> --dbpath /tmp/ssb-db.sqlite3 --offsetpath /tmp/ssb-db.offset
```

You should see:
```
client connected
In: 1 strm:true end:false Json {"name":["createHistoryStream"],"args":[{"id":"@SpDxZ/N2pG0NemSXhPbzbEy4KUH3028+z83FtbqyTEY=.ed25519","seq":1,"live":true,"keys":false}],"type":"source"}
got a chs request.
retrieved 2 entries
sent all entries
```

Now on the js side, go `createHistoryStream` for the rust feed id. You should see your rusty message :1st_place_medal: 

Post a reply to it:
```sh
ssb-server publish --type post --root <rust-post-key-id> --text "OMG hello rust!"
```

Get the js feed into rust:

```sh
./target/release/rustle --secret-file ~/.ssb/secret replicatefeed --feed <js-server-id> --key <key-of-js-ssb-server-without-@-or-.ed25519> --dbpath /tmp/ssb-db.sqlite3 --offsetpath /tmp/ssb-db.offset
```

You should see:
```
Latest sequence for feed is 7
client connected
got 1 new messages from server
validated messages
verified messages
appended 1 new messages to db
```

And now to see the reply from js:

```sh
./target/release/rustle --secret-file ~/.ssb/secret createHistoryStream --dbpath /tmp/ssb-db.sqlite3 --offsetpath /tmp/ssb-db.offset --feed <js-server-id>
```

And you should see:
```json
{"key":"%yLOqT6+w6gSzYZ9SqICc0pKD7PzAnjOQNZ0Ub7OJJik=.sha256","value":{"previous":"%RDSVWmArd1pTTE/uIog0lrDYqqE73SDG9NinNPOxDA8=.sha256","sequence":7,"author":"@z7oRp9UDnnWdCprvjBRs+PIKKaNhSdL6zLSI99aujTY=.ed25519","timestamp":1574679772837,"hash":"sha256","content":{"type":"post","root":"%iT6lKuNaTgcixW4LrG6u0L32i3pnSfDw2CYmcd2JVN4=.sha256","text":"OMG hello rust"},"signature":"cuCiPzzhvqaap2wWLqM0Qt8973D+uGHSQnVk3DGFqn3XVILIuEXFBGFRvx38Ot+nvlk2Kam6gOThILO1ekUsCg==.sig.ed25519"},"timestamp":1574679772838}
```

## Fast replication

Also for fun, try replicating a big feed. The validation / verification / appending is all batched to it's super fast!

## Noisy diff

OMG, the diff is super noisy, sorry, I always run `cargo fmt` before I push.

cc @ahdinosaur @AljoschaMeyer @mmckegg 

