### PR TITLE
Remove blocking/synchronous code inside async blocks

### DIFF
--- a/rustle/src/main.rs
+++ b/rustle/src/main.rs
@@ -329,17 +329,22 @@ fn main() -> Result<(), Error> {
                     eprintln!("got {} new messages from server", packets.len());
 
                     let previous: Option<Vec<u8>> =
+                        // This could block and get the entire async runtime to hang.
                         db.get_entry_by_seq(&author, latest_seq).unwrap();
 
                     // Later, we should add stuff to store into about broken feeds in the db.
                     // We should store why they broke and even store the offending message.
                     // Then we can do a avoid trying to replicate broken feeds over and over.
+
+                    // This could block and get the entire async runtime to hang.
                     par_validate_message_hash_chain_of_feed(&packets, previous.as_ref()).unwrap();
                     eprintln!("validated messages");
 
+                    // This could block and get the entire async runtime to hang.
                     par_verify_messages(&packets, None).unwrap();
                     eprintln!("verified messages");
 
+                    // This could block and get the entire async runtime to hang.
                     db.append_batch(&author, &packets).unwrap();
 
                     eprintln!("appended {} new messages to db", packets.len());

--- a/rustle/src/rpc.rs
+++ b/rustle/src/rpc.rs
@@ -34,10 +34,7 @@ pub struct SyncRpcHandler {
 impl SyncRpcHandler {
     // TODO: should be AsRef<Path>, but SsbDb uses str
     pub fn new<P: AsRef<str>>(db_path: P, offset_log_path: P) -> Self {
-        let db = Arc::new(Mutex::new(
-            // This could block and get the entire async runtime to hang.
-            SqliteSsbDb::new(&db_path, &offset_log_path),
-        ));
+        let db = Arc::new(Mutex::new(SqliteSsbDb::new(&db_path, &offset_log_path)));
         Self { db }
     }
 }


### PR DESCRIPTION
This is critical as it could hang the entire runtime and/or affect performance very negatively.
It is pointless to use async blocks if it's to use synchronous code inside them, as the major benefit is performance, otherwise you're better off with using only synchronous code.

I understand that the underlying database adapter is synchronous, therefore, that one should be made asynchronous first.

async-std claims to offer a mechanism to dynamically detect and move blocking code off the main asynchronous runtime threads, this helps, but it's still bad for performance.

- [x] Use asynchronous Mutex
- [ ] Make database adapter asynchronous
- [ ] Make parallel message verification asynchronous